### PR TITLE
Hide translation install failures

### DIFF
--- a/lib/capistrano/wearerequired/tasks/wordpress.rake
+++ b/lib/capistrano/wearerequired/tasks/wordpress.rake
@@ -9,9 +9,9 @@ namespace :wordpress do
     on roles(:app) do
       within release_path do
         fetch(:wp_languages).each do |language|
-          execute :wp, "language core install #{language}", raise_on_non_zero_exit: false
-          execute :wp, "plugin list --field=name | xargs -I % wp language plugin install % #{language}", raise_on_non_zero_exit: false
-          execute :wp, "theme list --field=name | xargs -I % wp language theme install % #{language}", raise_on_non_zero_exit: false
+          execute :wp, "language core install #{language} 2> /dev/null", raise_on_non_zero_exit: false
+          execute :wp, "plugin list --field=name | xargs -I % wp language plugin install % #{language} 2> /dev/null", raise_on_non_zero_exit: false
+          execute :wp, "theme list --field=name | xargs -I % wp language theme install % #{language} 2> /dev/null", raise_on_non_zero_exit: false
         end
       end
     end

--- a/lib/capistrano/wearerequired/tasks/wordpress.rake
+++ b/lib/capistrano/wearerequired/tasks/wordpress.rake
@@ -25,9 +25,9 @@ namespace :wordpress do
 
     on roles(:app) do
       within release_path do
-        execute :wp, "language core update", raise_on_non_zero_exit: false
-        execute :wp, "language plugin update --all", raise_on_non_zero_exit: false
-        execute :wp, "language theme update --all", raise_on_non_zero_exit: false
+        execute :wp, "language core update"
+        execute :wp, "language plugin update --all"
+        execute :wp, "language theme update --all"
       end
     end
   end


### PR DESCRIPTION
The normal output is helpful to see which languages have been installed and if they were downloaded or fetched from the cache.

See #22